### PR TITLE
nlp2json: Improvements and migrate to python3

### DIFF
--- a/nlp2json.py
+++ b/nlp2json.py
@@ -1,15 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """ @todo add docstring """
-
-# ### imports ###
-
-from __future__ import (
-    absolute_import,
-    division,
-    print_function  # ,
-    #  unicode_literals
-)
 
 import io
 import json
@@ -24,23 +15,29 @@ if len(sys.argv) > 1:
     nirsoft_dir = sys.argv[1]
 else:
     nirsoft_dir = os.path.join(home, 'scoop/apps/nirlauncher/current/NirSoft')
+    if not os.path.exists(nirsoft_dir):
+        nirsoft_dir = os.path.join(os.getenv('SCOOP'), 'apps/nirlauncher/current/NirSoft')
+nirsoft_dir = os.path.normpath(nirsoft_dir)
 
-nirsoft_dir = re.sub(r'\\', '/', nirsoft_dir)
-nirsoft_nlp = os.path.join(nirsoft_dir, 'nirsoft.nlp')
+nirsoft_nlp = os.path.normpath(os.path.join(nirsoft_dir, 'nirsoft.nlp'))
 
 if len(sys.argv) > 2:
     nirlauncher_json = sys.argv[2]
 else:
-    nirlauncher_json = os.path.join(
-        os.path.dirname(nirsoft_dir), 'manifest.json')
+    nirlauncher_json = os.path.join(os.path.dirname(nirsoft_dir), 'manifest.json')
+nirlauncher_json = os.path.normpath(nirlauncher_json)
 
-nirlauncher_json = re.sub(r'\\', '/', nirlauncher_json)
+try:
+    with io.open(nirlauncher_json, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+except IOError as err:
+    exit(err)
 
-with io.open(nirlauncher_json, 'r', encoding='utf-8') as f:
-    data = json.load(f)
-
-with io.open(nirsoft_nlp, 'r', encoding='utf-8') as f:
-    lines = f.readlines()
+try:
+    with io.open(nirsoft_nlp, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+except IOError as err:
+    exit(err)
 
 exes = {}
 
@@ -71,7 +68,7 @@ data['architecture']['64bit']['shortcuts'] = [[
     "Nirlauncher - Run over 200 freeware utilities from nirsoft.net"
 ]]
 
-for base in sorted(exes, key=unicode.lower):
+for base in sorted(exes, key=str.lower):
     h = exes[base]
     desc = h['ShortDesc']
     desc = re.sub(r'"', "'", desc)
@@ -82,12 +79,16 @@ for base in sorted(exes, key=unicode.lower):
     if desc:
         desc = desc[0].upper() + desc[1:]
     print("%-25s %s" % (os.path.splitext(base)[0], desc))
-    path = 'NirSoft/' + h['exe']
+
+    path = os.path.join('NirSoft', h['exe'])
     path = re.sub(r'\\', '/', path)
     data['architecture']['32bit']['bin'].append(path)
-    fullpath = nirsoft_dir + '/' + h['exe']
-    stdout = subprocess.check_output(["exetype", fullpath])
-    if re.search('GUI', stdout):
+
+    # Get binary information
+    fullpath = os.path.join(nirsoft_dir, h['exe'])
+    stdout = subprocess.check_output(['7z.exe', 'l', fullpath], universal_newlines=True)
+
+    if re.search('Subsystem = Windows GUI', stdout):
         if 'AppName' in h and h['AppName']:
             appname = h['AppName']
         else:
@@ -98,25 +99,29 @@ for base in sorted(exes, key=unicode.lower):
         data['architecture']['32bit']['shortcuts'].append([path, name])
     if 'exe64' not in h or not h['exe64']:
         data['architecture']['64bit']['bin'].append(path)
-        if re.search('GUI', stdout):
+        if re.search('Subsystem = Windows GUI', stdout):
             data['architecture']['64bit']['shortcuts'].append([path, name])
         continue
 
-    path = 'NirSoft/' + h['exe64']
+    path = os.path.join('NirSoft', h['exe64'])
     path = re.sub(r'\\', '/', path)
     data['architecture']['64bit']['bin'].append(path)
-    if re.search('GUI', stdout):
+    if re.search('Subsystem = Windows GUI', stdout):
         data['architecture']['64bit']['shortcuts'].append([path, name])
 
-jsons = json.dumps(data, sort_keys=True, indent=4, separators=(',', ': '))
-
-utf8 = jsons.decode('utf-8')
-utf8 += "\n"
+json_dump = json.dumps(data, sort_keys=False, indent=4, separators=(',', ': '))
 
 nirlauncher_tmp = nirlauncher_json + '.tmp'
 
-with io.open(nirlauncher_tmp, 'w', newline='\n') as f:
-    written = f.write(utf8)
+try:
+    with io.open(nirlauncher_tmp, 'w', newline='\n', encoding='utf-8') as f:
+        f.write(json_dump)
+        f.write('\n')
+except IOError as err:
+    exit(err)
 
-os.remove(nirlauncher_json)
-os.rename(nirlauncher_tmp, nirlauncher_json)
+try:
+    os.remove(nirlauncher_json)
+    os.rename(nirlauncher_tmp, nirlauncher_json)
+except IOError as err:
+    exit(err)


### PR DESCRIPTION
- Migrate to python3
- Use `7z l some.exe` to find out if binary is a GUI application (every Scoop user has it installed)
- Make use of path.join and path.normpath
- Try `%SCOOP%` if `~/scoop` is not found
- Add a bit of error handling