### PR TITLE
Fix download url for DiskSpd

### DIFF
--- a/bucket/diskspd.json
+++ b/bucket/diskspd.json
@@ -11,7 +11,7 @@
             "bin": "amd64/diskspd.exe"
         }
     },
-    "url": "https://github.com/microsoft/diskspd/releases/download/v2.0.21a/DiskSpd-2.0.21a.zip",
+    "url": "https://github.com/microsoft/diskspd/releases/download/v2.0.21a/DiskSpd.zip",
     "hash": "d02f6be976c518d4134e62af7f518baad6c7c81f924caafbeba65bd0831ce139",
     "checkver": {
         "github": "https://github.com/microsoft/diskspd",


### PR DESCRIPTION
It seems the download url of [DiskSpd](https://github.com/microsoft/diskspd/releases/tag/v2.0.21a) has changed.