### PR TITLE
usbtreeview@3.8.6: Fix hash

### DIFF
--- a/bucket/usbtreeview.json
+++ b/bucket/usbtreeview.json
@@ -6,11 +6,11 @@
     "architecture": {
         "32bit": {
             "url": "https://www.uwe-sieber.de/files/UsbTreeView_Win32.zip",
-            "hash": "2082b4036ebc3f56e8da5d50e88f8c034d38de85cf38187fbe7083a2842ff8a9"
+            "hash": "977d968e4fab4f1798aecaed447efa11fcbfc33c92596a576712076d95db88fa"
         },
         "64bit": {
             "url": "https://www.uwe-sieber.de/files/UsbTreeView_x64.zip",
-            "hash": "b4b29f918b7571c95cab14414c310e317ba981c8bb7c9a5e5119fd9b63064afb"
+            "hash": "757b5038b622d18d138d2a537a534e546050704401d9f7ffa2d5c84c68681966"
         }
     },
     "bin": "UsbTreeView.exe",


### PR DESCRIPTION
Confirmed with multiple downloads of both 32- and 64-bit.