### PR TITLE
usbtreeview: Add extract_dir and arm64 architecture

### DIFF
--- a/bucket/usbtreeview.json
+++ b/bucket/usbtreeview.json
@@ -6,11 +6,18 @@
     "architecture": {
         "32bit": {
             "url": "https://www.uwe-sieber.de/files/UsbTreeView_Win32.zip",
-            "hash": "39e3c393b18d98776773bbcb837210184e8e47515b2d264189d6b8759affc3e2"
+            "hash": "39e3c393b18d98776773bbcb837210184e8e47515b2d264189d6b8759affc3e2",
+            "extract_dir": "Win32"
         },
         "64bit": {
             "url": "https://www.uwe-sieber.de/files/UsbTreeView_x64.zip",
-            "hash": "37793a6e68bef1eaca538b31849d21014d978fa30bab75967f454d007afc37bb"
+            "hash": "37793a6e68bef1eaca538b31849d21014d978fa30bab75967f454d007afc37bb",
+            "extract_dir": "x64"
+        },
+        "arm64": {
+            "url": "https://www.uwe-sieber.de/files/UsbTreeView_arm64.zip",
+            "hash": "3C347873C0463DC264242F1DCC7FEC002C39A849228C8EF095F4B68CF2BF5C55",
+            "extract_dir": "arm64"
         }
     },
     "bin": "UsbTreeView.exe",
@@ -28,6 +35,9 @@
             },
             "64bit": {
                 "url": "https://www.uwe-sieber.de/files/UsbTreeView_x64.zip"
+            },
+            "arm64": {
+                "url": "https://www.uwe-sieber.de/files/UsbTreeView_arm64.zip"
             }
         }
     }


### PR DESCRIPTION
- Adds needed extract_dir property for every architecture
- Adds the arm64 architecture